### PR TITLE
Add run as script compatability to matrix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,19 +8,21 @@ The distributions (an sdist .tar.gz and a bdist .whl) will be written to ./dist/
 
 Here's a compatibility summary of the five approaches demonstrated:
 
-+-------------+---------------------+------------+---------------+---------------+-------------------+
-| Module      | Description         | In stdlib? | Works on Py2? | Works on Py3? | Works in zipfile? |
-+=============+=====================+============+===============+===============+===================+
-| example1.py | os.path.join        |     yes    |      yes      |      yes      |         no        |
-+-------------+---------------------+------------+---------------+---------------+-------------------+
-| example2.py | pkgutil             |     yes    |      yes      |      yes      |        yes        |
-+-------------+---------------------+------------+---------------+---------------+-------------------+
-| example3.py | pkg_resources       |     no     |      yes      |      yes      |        yes        |
-+-------------+---------------------+------------+---------------+---------------+-------------------+
-| example4.py | importlib.resources |     yes    |       no      |   yes (3.7+)  |        yes        |
-+-------------+---------------------+------------+---------------+---------------+-------------------+
-| example5.py | importlib_resources |     no     |      yes      |      yes      |        yes        |
-+-------------+---------------------+------------+---------------+---------------+-------------------+
++-------------+---------------------+------------+---------------+---------------+-------------------+-----------------+
+| Module      | Description         | In stdlib? | Works on Py2? | Works on Py3? | Works in zipfile? | Run as script?* |
++=============+=====================+============+===============+===============+===================+=================+
+| example1.py | os.path.join        |     yes    |      yes      |      yes      |         no        |       yes       |
++-------------+---------------------+------------+---------------+---------------+-------------------+-----------------+
+| example2.py | pkgutil             |     yes    |      yes      |      yes      |        yes        |        no       |
++-------------+---------------------+------------+---------------+---------------+-------------------+-----------------+
+| example3.py | pkg_resources       |     no     |      yes      |      yes      |        yes        |       yes       |
++-------------+---------------------+------------+---------------+---------------+-------------------+-----------------+
+| example4.py | importlib.resources |     yes    |       no      |   yes (3.7+)  |        yes        |       yes       |
++-------------+---------------------+------------+---------------+---------------+-------------------+-----------------+
+| example5.py | importlib_resources |     no     |      yes      |      yes      |        yes        |       yes       |
++-------------+---------------------+------------+---------------+---------------+-------------------+-----------------+
+
+* This could be considered `an anti-pattern <https://mail.python.org/pipermail/python-3000/2007-April/006793.html>`_
 
 If you are interested in creating an executable zip from source, you can use stdlib `zipapp <https://docs.python.org/3/library/zipapp.html>`_ utility (Python 3.5+):
 


### PR DESCRIPTION
Following our discussion [on StackOverflow](https://stackoverflow.com/questions/6028000/how-to-read-a-static-file-from-inside-a-python-package#comment120482012_58941536), I thought it would be helpful for people reading this repo to understand this limitation (even though it probably should make them think twice about how they are reading accessing this file anyway 😄 ).

I found this repo very helpful! Thank you!

Here's what the README looks like now:

<img width="881" alt="image" src="https://user-images.githubusercontent.com/23139455/123714288-dd6bfd00-d82a-11eb-984c-6ec483e18c15.png">
